### PR TITLE
Add support to configure Rahmen using a file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "config"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
+dependencies = [
+ "lazy_static",
+ "nom",
+ "rust-ini",
+ "serde 1.0.119",
+ "serde-hjson",
+ "serde_json",
+ "toml",
+ "yaml-rust",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,7 +540,7 @@ dependencies = [
  "jpeg-decoder",
  "num-iter",
  "num-rational 0.3.2",
- "num-traits",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -545,6 +561,12 @@ checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jobserver"
@@ -571,10 +593,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 0.1.10",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
+dependencies = [
+ "serde 0.8.23",
+ "serde_test",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
@@ -657,13 +708,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -674,7 +736,7 @@ checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -685,7 +747,7 @@ checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -696,7 +758,16 @@ checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -772,6 +843,7 @@ name = "rahmen"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "config",
  "convert_case",
  "ctrlc",
  "fltk",
@@ -785,6 +857,8 @@ dependencies = [
  "pathfinder_geometry",
  "regex",
  "rexiv2",
+ "serde 1.0.119",
+ "serde_derive",
  "timely",
 ]
 
@@ -881,6 +955,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +968,12 @@ checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "same-file"
@@ -921,9 +1007,28 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
+
+[[package]]
+name = "serde"
 version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bdd36f49e35b61d49efd8aa7fc068fd295961fd2286d0b2ee9a4c7a14e99cc3"
+
+[[package]]
+name = "serde-hjson"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
+dependencies = [
+ "lazy_static",
+ "linked-hash-map 0.3.0",
+ "num-traits 0.1.43",
+ "regex",
+ "serde 0.8.23",
+]
 
 [[package]]
 name = "serde_derive"
@@ -934,6 +1039,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde 1.0.119",
+]
+
+[[package]]
+name = "serde_test"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
+dependencies = [
+ "serde 0.8.23",
 ]
 
 [[package]]
@@ -956,6 +1081,12 @@ dependencies = [
  "freetype-sys",
  "pkg-config",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -1016,7 +1147,7 @@ dependencies = [
  "abomonation_derive",
  "crossbeam-channel",
  "getopts",
- "serde",
+ "serde 1.0.119",
  "serde_derive",
  "timely_bytes",
  "timely_communication",
@@ -1037,7 +1168,7 @@ dependencies = [
  "abomonation_derive",
  "crossbeam-channel",
  "getopts",
- "serde",
+ "serde 1.0.119",
  "serde_derive",
  "timely_bytes",
  "timely_logging",
@@ -1047,6 +1178,15 @@ dependencies = [
 name = "timely_logging"
 version = "0.11.1"
 source = "git+https://github.com/TimelyDataflow/timely-dataflow#de69cfc4d7da29d4e210cd06fc431650477e5530"
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde 1.0.119",
+]
 
 [[package]]
 name = "unicode-width"
@@ -1065,6 +1205,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "walkdir"
@@ -1121,4 +1267,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map 0.5.4",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ debug = true
 
 [dependencies]
 clap = { version = "3.0.0-beta.2", default-features = false, features = ["color", "std"] }
+config = "0.10.1"
 convert_case = "0.4.0"
 ctrlc = "3.1.7"
 fltk = { version = "0.12.2", optional = true, features = ["fltk-shared"] }
@@ -30,6 +31,8 @@ mozjpeg = "0.8.21"
 pathfinder_geometry = "0.5.1"
 rexiv2 = "0.9.1"
 regex = "1"
+serde = "1.0.119"
+serde_derive = "1.0.119"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
 
 [dependencies.image]

--- a/rahmen.toml
+++ b/rahmen.toml
@@ -1,6 +1,7 @@
 # Configuration for Rahmen
 
-font_size = 30
+# Font size of the status line
+font_size = 24
 # Delay between transitions
 delay = 90
 

--- a/rahmen.toml
+++ b/rahmen.toml
@@ -1,0 +1,44 @@
+
+font_size = 30
+# Delay between transitions
+delay = 90
+
+[[status_line]]
+exif_tags = ["Iptc.Application2.ObjectName"]
+
+[[status_line]]
+exif_tags = ["Iptc.Application2.ObjectName"]
+
+[[status_line]]
+exif_tags = ["Iptc.Application2.SubLocation"]
+
+[[status_line]]
+exif_tags = ["Iptc.Application2.City"]
+
+[[status_line]]
+exif_tags = ["Iptc.Application2.ProvinceState"]
+
+[[status_line]]
+exif_tags = ["Iptc.Application2.CountryName"]
+
+[[status_line]]
+exif_tags = ["Exif.Photo.DateTimeOriginal"]
+# convert date to German format
+regex = '(?P<y>\d{4})[-:]0*(?P<M>\d+)[-:]0*(?P<d>\d+)\s+0*(?P<h>\d+:)0*(?P<m>\d+):(?P<s>\d{2})'
+# TODO find better way to insert comma after year, might lead to a surplus comma if no time is found in metadata?
+# (but Exif.Photo.DateTimeOriginal _should_ contain a time)
+replace = '$d.$M.$y, $h$m'
+
+[[status_line]]
+exif_tags = ["Xmp.dc.creator"]
+# remove numeric strings starting with plus sign after whitespace (phone numbers)
+regex = '(\s\+\d+)|(\b<?www.)'
+replace = ''
+# and convert from UPPER CASE to Title Case
+capitalize = true
+# // remove leading zeros after dot (date)
+# let re = Regex::new(r"\.0").unwrap();
+# let s = re.replace_all(&s, ".").into_owned();
+# // remove www stuff
+# let re = Regex::new(r"\b<?www.").unwrap();
+# let s = re.replace_all(&s, "").into_owned();

--- a/rahmen.toml
+++ b/rahmen.toml
@@ -1,3 +1,4 @@
+# Configuration for Rahmen
 
 font_size = 30
 # Delay between transitions
@@ -36,9 +37,3 @@ regex = '(\s\+\d+)|(\b<?www.)'
 replace = ''
 # and convert from UPPER CASE to Title Case
 capitalize = true
-# // remove leading zeros after dot (date)
-# let re = Regex::new(r"\.0").unwrap();
-# let s = re.replace_all(&s, ".").into_owned();
-# // remove www stuff
-# let re = Regex::new(r"\b<?www.").unwrap();
-# let s = re.replace_all(&s, "").into_owned();

--- a/src/bin/rahmen.rs
+++ b/src/bin/rahmen.rs
@@ -144,7 +144,8 @@ fn main() -> RahmenResult<()> {
 
     let duration_millis = (matches
         .value_of("time")
-        .map(|time_str| (f64::from_str(time_str).unwrap()))
+        .map(str::parse)
+        .transpose()?
         .or(settings.delay)
         .unwrap_or(90.)
         * 1000f64) as u64;

--- a/src/bin/rahmen.rs
+++ b/src/bin/rahmen.rs
@@ -110,8 +110,7 @@ fn main() -> RahmenResult<()> {
             Arg::new("font_size")
                 .long("font_size")
                 .takes_value(true)
-                .validator(|v| f32::from_str(v))
-                .default_value("24"),
+                .validator(|v| f32::from_str(v)),
         )
         .get_matches();
 
@@ -151,6 +150,14 @@ fn main() -> RahmenResult<()> {
         * 1000f64) as u64;
     let delay = Duration::from_millis(duration_millis);
     println!("Delay: {:?}", delay);
+
+    // font size to use (px)
+    let font_size_f = matches
+        .value_of("font_size")
+        .map(str::parse)
+        .transpose()?
+        .or(settings.font_size)
+        .unwrap_or(30.);
 
     // initialization for timely dataflow
     let allocator = timely::communication::allocator::Thread::new();
@@ -241,8 +248,6 @@ fn main() -> RahmenResult<()> {
     let start_time = Instant::now();
     let mut dimensions = None;
 
-    // font size to use (px)
-    let font_size_f = matches.value_of("font_size").unwrap().parse().unwrap();
     input_configuration.send(Configuration::FontSize(font_size_f));
     // enlarge font canvas vertically by this factor (default given here: 1.5)
     input_configuration.send(Configuration::FontCanvasVStretch(1.5));

--- a/src/bin/rahmen.rs
+++ b/src/bin/rahmen.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 use std::io::BufReader;
+use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -25,7 +26,6 @@ use rahmen::errors::{RahmenError, RahmenResult};
 use rahmen::font::FontRenderer;
 use rahmen::provider::{load_image_from_path, Provider, StatusLineFormatter};
 use rahmen::provider_list::ListProvider;
-use std::path::Path;
 
 /// dataflow control, this is used as result R part
 #[derive(Copy, Clone, Eq, PartialEq)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,8 @@ pub struct Element {
 pub struct Settings {
     /// Transition delay between images
     pub delay: Option<f64>,
+    /// Font size of the status line
+    pub font_size: Option<f32>,
     /// Status line elements
     pub status_line: Vec<Element>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,23 @@
+//! Configuration data for Rahmen
+
+/// An element of the status line
+#[derive(Debug, Deserialize, Clone)]
+pub struct Element {
+    /// Capitalize the words in the tag
+    pub capitalize: Option<bool>,
+    /// Collection of exif tags, ordered by priority
+    pub exif_tags: Vec<String>,
+    /// Optional regular expression to extract data. Requires replacement pattern
+    pub regex: Option<String>,
+    /// Optional replacement pattern. Requires regex
+    pub replace: Option<String>,
+}
+
+/// Config file root structure
+#[derive(Debug, Deserialize, Clone)]
+pub struct Settings {
+    /// Transition delay between images
+    pub delay: Option<f64>,
+    /// Status line elements
+    pub status_line: Vec<Element>,
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,10 +7,14 @@ use std::sync::Arc;
 /// Error types within Rahmen
 #[derive(std::fmt::Debug)]
 pub enum RahmenError {
+    /// Errors originating from config loading
+    ConfigError(Arc<config::ConfigError>),
     /// Errors interacting with I/O
     IoError(std::io::Error),
     /// Errors from the image library
     ImageError(Arc<image::error::ImageError>),
+    /// An error originating from regex processing
+    RegexError(regex::Error),
     /// Pseudo-error to indicate a retry condition
     Retry,
     /// Errors from rexiv2
@@ -25,8 +29,10 @@ pub type RahmenResult<T> = Result<T, RahmenError>;
 impl fmt::Display for RahmenError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
+            RahmenError::ConfigError(err) => err.fmt(f),
             RahmenError::IoError(err) => err.fmt(f),
             RahmenError::ImageError(err) => err.fmt(f),
+            RahmenError::RegexError(err) => err.fmt(f),
             RahmenError::Retry => write!(f, "Retry"),
             RahmenError::Rexiv2Error(err) => err.fmt(f),
             RahmenError::Terminate => write!(f, "Terminate"),
@@ -37,14 +43,23 @@ impl fmt::Display for RahmenError {
 impl Error for RahmenError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
+            RahmenError::ConfigError(err) => err.source(),
             RahmenError::IoError(err) => err.source(),
             RahmenError::ImageError(err) => err.source(),
+            RahmenError::RegexError(err) => err.source(),
             RahmenError::Retry => None,
             RahmenError::Rexiv2Error(err) => err.source(),
             RahmenError::Terminate => None,
         }
     }
 }
+
+impl From<config::ConfigError> for RahmenError {
+    fn from(err: config::ConfigError) -> Self {
+        RahmenError::ConfigError(Arc::new(err))
+    }
+}
+
 impl From<std::io::Error> for RahmenError {
     fn from(err: std::io::Error) -> Self {
         RahmenError::IoError(err)
@@ -56,6 +71,13 @@ impl From<image::error::ImageError> for RahmenError {
         RahmenError::ImageError(Arc::new(err))
     }
 }
+
+impl From<regex::Error> for RahmenError {
+    fn from(err: regex::Error) -> Self {
+        RahmenError::RegexError(err)
+    }
+}
+
 impl From<rexiv2::Rexiv2Error> for RahmenError {
     fn from(err: rexiv2::Rexiv2Error) -> Self {
         RahmenError::Rexiv2Error(err)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,6 +2,7 @@
 
 use std::error::Error;
 use std::fmt;
+use std::num::ParseFloatError;
 use std::sync::Arc;
 
 /// Error types within Rahmen
@@ -13,6 +14,8 @@ pub enum RahmenError {
     IoError(std::io::Error),
     /// Errors from the image library
     ImageError(Arc<image::error::ImageError>),
+    /// Parsing a float failed
+    ParseFloatError(ParseFloatError),
     /// An error originating from regex processing
     RegexError(regex::Error),
     /// Pseudo-error to indicate a retry condition
@@ -32,6 +35,7 @@ impl fmt::Display for RahmenError {
             RahmenError::ConfigError(err) => err.fmt(f),
             RahmenError::IoError(err) => err.fmt(f),
             RahmenError::ImageError(err) => err.fmt(f),
+            RahmenError::ParseFloatError(err) => err.fmt(f),
             RahmenError::RegexError(err) => err.fmt(f),
             RahmenError::Retry => write!(f, "Retry"),
             RahmenError::Rexiv2Error(err) => err.fmt(f),
@@ -46,6 +50,7 @@ impl Error for RahmenError {
             RahmenError::ConfigError(err) => err.source(),
             RahmenError::IoError(err) => err.source(),
             RahmenError::ImageError(err) => err.source(),
+            RahmenError::ParseFloatError(err) => err.source(),
             RahmenError::RegexError(err) => err.source(),
             RahmenError::Retry => None,
             RahmenError::Rexiv2Error(err) => err.source(),
@@ -69,6 +74,12 @@ impl From<std::io::Error> for RahmenError {
 impl From<image::error::ImageError> for RahmenError {
     fn from(err: image::error::ImageError) -> Self {
         RahmenError::ImageError(Arc::new(err))
+    }
+}
+
+impl From<ParseFloatError> for RahmenError {
+    fn from(err: ParseFloatError) -> Self {
+        RahmenError::ParseFloatError(err)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,12 @@
     variant_size_differences
 )]
 
+#[macro_use]
+extern crate serde_derive;
+
 use std::time::{Duration, Instant};
 
+pub mod config;
 pub mod dataflow;
 pub mod display;
 #[cfg(feature = "fltk")]


### PR DESCRIPTION
We introduce a configuration file that allows to specify the composition
of the status line. The status line consists of fragments derived from
meta data tags, which can be transformed using regular expressions and
capitalization. Currently, a single regular expression can be applied.

In the future, more configuration items are intended to be moved to the
configuration file.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>