### PR TITLE
Improve Debian integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
  "serde 1.0.119",
  "serde_derive",
  "timely",
+ "xdg",
 ]
 
 [[package]]
@@ -1268,6 +1269,12 @@ checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "xdg"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ A simple tool to show images on a screen with little dependencies and resource r
 depends = "$auto"
 section = "utility"
 priority = "optional"
-conf-files = ["rahmen.toml"]
+conf-files = ["/etc/rahmen.toml"]
 assets = [
     ["rahmen.toml", "etc/", "644"],
     ["target/release/rahmen", "usr/bin/", "755"],

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,25 @@ regex = "1"
 serde = "1.0.119"
 serde_derive = "1.0.119"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
+xdg = "2.2.0"
 
 [dependencies.image]
 version = "0.23.12"
 default-features = false
 # Disable jpeg_rayon
 features = ["jpeg"]
+
+[package.metadata.deb]
+maintainer = "Moritz Hoffmann <antiguru@gmail.com>"
+copyright = "2021, Moritz Hoffmann <antiguru@gmail.com>"
+license-file = ["LICENSE", "4"]
+extended-description = """\
+A simple tool to show images on a screen with little dependencies and resource requirements."""
+depends = "$auto"
+section = "utility"
+priority = "optional"
+conf-files = ["rahmen.toml"]
+assets = [
+    ["rahmen.toml", "etc/", "644"],
+    ["target/release/rahmen", "usr/bin/", "755"],
+]

--- a/src/bin/rahmen.rs
+++ b/src/bin/rahmen.rs
@@ -61,6 +61,9 @@ fn suppress_err<T>(result: RahmenResult<T>) -> RunResult<T> {
 
 type RunResult<T> = Result<T, RunControl>;
 
+#[cfg(unix)]
+const SYSTEM_CONFIG_PATH: &str = "/etc/rahmen.toml";
+
 fn main() -> RahmenResult<()> {
     let matches = App::new("Rahmen client")
         .arg(
@@ -133,16 +136,28 @@ fn main() -> RahmenResult<()> {
         Box::new(rahmen::provider_glob::create(input)?)
     };
 
-    let mut c = config::Config::default();
     let dirs = xdg::BaseDirectories::new().unwrap();
-    c.merge(config::File::from(
-        matches
-            .value_of("config")
-            .map(Into::into)
-            .or(dirs.find_config_file("rahmen.toml"))
-            .expect("Config file not found"),
-    ))?;
-    let settings: Settings = c.try_into()?;
+    let settings: Settings = if let Some(path) = matches
+        .value_of("config")
+        .map(Into::into)
+        .or(dirs.find_config_file("rahmen.toml"))
+        .or_else(|| {
+            #[cfg(unix)]
+            if std::fs::metadata(SYSTEM_CONFIG_PATH).is_ok() {
+                Some(SYSTEM_CONFIG_PATH.into())
+            } else {
+                None
+            }
+            #[cfg(not(unix))]
+            None
+        }) {
+        let mut c = config::Config::default();
+        c.merge(config::File::from(path))?;
+        c.try_into()?
+    } else {
+        eprintln!("Config file not found, continuing with default settings");
+        Default::default()
+    };
     let status_line_formatter = StatusLineFormatter::new(settings.status_line.iter().cloned())?;
 
     let buffer_max_size: usize = matches

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,7 @@ pub struct Replacement {
 }
 
 /// Config file root structure
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Default, Deserialize, Clone)]
 pub struct Settings {
     /// Transition delay between images
     pub delay: Option<f64>,


### PR DESCRIPTION
This enables the `cargo deb` command to generate a functional binary package.

The package will not have support for fltk because of its handling of shared libraries.