### PR TITLE
Make the crate publishable on crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,23 +286,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
-dependencies = [
- "cfg-if",
- "lazy_static",
-]
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "ctrlc"
@@ -543,43 +538,37 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.16"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.16"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn 1.0.75",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-task"
-version = "0.3.16"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.16"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "autocfg",
  "futures-core",
  "futures-macro",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -892,12 +881,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,18 +913,6 @@ checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -1189,9 +1160,9 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
-version = "0.4.4"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,16 @@ version = "0.2.0"
 authors = ["Moritz Hoffmann <antiguru@gmail.com>", "sys3175 <https://github.com/sys3175>"]
 edition = "2024"
 rust-version = "1.85"
-license = "GPL"
+license = "GPL-3.0-only"
 description = "Rahmen is a lightweight image presenter"
 readme = "README.md"
+repository = "https://github.com/antiguru/rahmen"
+homepage = "https://github.com/antiguru/rahmen"
+documentation = "https://docs.rs/rahmen"
+keywords = ["slideshow", "image", "framebuffer", "exif", "picture-frame"]
+categories = ["multimedia::images", "command-line-utilities"]
+# Development-only files that don't belong in the published crate.
+exclude = [".github/", "rustfmt.toml", "test.py"]
 
 [features]
 default = []


### PR DESCRIPTION
## Summary

Gets `rahmen` into a state where it can be published to crates.io. The earlier modernization already removed the hard blocker (the unpinned `timely` git dependency), so the remaining work is crate metadata + lockfile hygiene.

`cargo publish --dry-run` now **packages and verifies with zero warnings**, and the crate name `rahmen` is currently free on crates.io.

## Changes

- **Valid SPDX license** — `license = "GPL"` → `license = "GPL-3.0-only"`. crates.io rejects the bare, non-SPDX `GPL` on upload. The bundled `LICENSE` is the GPLv3 text and the README states "version 3", so `GPL-3.0-only` is the faithful identifier.
- **Complete manifest metadata** — added `repository`, `homepage`, `documentation`, `keywords`, and `categories` (clears cargo's "manifest has no documentation, homepage or repository" warning and makes the crate discoverable).
- **Leaner package** — `exclude` development-only files (`.github/`, `rustfmt.toml`, `test.py`). The splash PNG (`src/bin/rahmen.png`, used by `include_bytes!`) and the README-referenced examples (`postprocess.py`, `rahmen.toml`, `utils/picframe.sh`) are kept.
- **No yanked deps** — refreshed `Cargo.lock` off yanked transitive crates (`crossbeam-channel` 0.5.1, `crossbeam-utils` 0.8.5, `futures-util` 0.3.16), which also dropped some stale `proc-macro-hack`/`proc-macro-nested` crates. This matters for `cargo install rahmen` and verification builds.

## Verification (local)
- `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test` ✅
- `cargo fmt --all -- --check` ✅
- `cargo publish --dry-run` ✅ — packages 23 files, verification build succeeds, **no warnings**.

## Notes for the actual publish
- This branch is based on `master`, which still has the `fltk` optional display (PR #24 swaps it for `minifb`). Publish blockers here are independent of that choice — merge whichever display backend you prefer first; the only overlap with #24 is `Cargo.lock` (auto-regenerates).
- `license` is set to `GPL-3.0-only`; if you actually intend "version 3 **or later**", change it to `GPL-3.0-or-later`.
- Building `rahmen` requires system libraries (gexiv2, fontconfig, python3-dev). This doesn't block `cargo publish` (crates.io doesn't compile), but `docs.rs` may need `[package.metadata.docs.rs]` tweaks to build docs — a post-publish nicety, not a blocker.
- The publish itself (`cargo publish`) requires your crates.io API token, so that final step is yours to run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KQTNpGFjZnPQ6mh61YwTC6)_