### PR TITLE
Make the workspace publishable on crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,23 +305,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
-dependencies = [
- "cfg-if",
- "lazy_static",
-]
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "ctrlc"
@@ -655,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.16"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -665,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.16"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
@@ -688,15 +683,13 @@ checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.16"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn 1.0.75",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -707,17 +700,16 @@ checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.16"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.16"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -726,9 +718,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -1161,12 +1150,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,18 +1198,6 @@ dependencies = [
  "proc-macro2",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -1560,9 +1531,9 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
-version = "0.4.4"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,16 @@ version = "0.2.0"
 authors = ["Moritz Hoffmann <antiguru@gmail.com>", "sys3175 <https://github.com/sys3175>"]
 edition = "2024"
 rust-version = "1.85"
-license = "GPL"
+license = "GPL-3.0-only"
 description = "Rahmen is a lightweight image presenter"
 readme = "README.md"
+repository = "https://github.com/antiguru/rahmen"
+homepage = "https://github.com/antiguru/rahmen"
+documentation = "https://docs.rs/rahmen"
+keywords = ["slideshow", "image", "framebuffer", "exif", "picture-frame"]
+categories = ["multimedia::images", "command-line-utilities"]
+# Development-only files that don't belong in the published crate.
+exclude = [".github/", "rustfmt.toml", "test.py"]
 
 [workspace]
 members = ["rahmen-exiv2"]
@@ -35,7 +42,7 @@ log = "0.4"
 minifb = { version = "0.28", optional = true }
 mozjpeg = { version = "0.10", default-features = false }
 pathfinder_geometry = "0.5"
-rahmen-exiv2 = { path = "rahmen-exiv2" }
+rahmen-exiv2 = { path = "rahmen-exiv2", version = "0.2.0" }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 timely = "0.12"

--- a/rahmen-exiv2/Cargo.toml
+++ b/rahmen-exiv2/Cargo.toml
@@ -4,8 +4,14 @@ version = "0.2.0"
 authors = ["Moritz Hoffmann <antiguru@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"
-license = "GPL"
+license = "GPL-3.0-only"
 description = "Minimal safe wrapper over libexiv2 for rahmen"
+repository = "https://github.com/antiguru/rahmen"
+homepage = "https://github.com/antiguru/rahmen"
+documentation = "https://docs.rs/rahmen-exiv2"
+readme = "README.md"
+keywords = ["exiv2", "exif", "metadata", "image", "iptc"]
+categories = ["api-bindings", "multimedia::images"]
 
 [dependencies]
 cxx = "1"

--- a/rahmen-exiv2/README.md
+++ b/rahmen-exiv2/README.md
@@ -1,0 +1,31 @@
+# rahmen-exiv2
+
+A minimal, safe wrapper over [libexiv2](https://exiv2.org/), built for
+[rahmen](https://github.com/antiguru/rahmen).
+
+It exposes only the read-only image-metadata operations rahmen needs — opening an
+image and reading a single Exif/Iptc/Xmp tag as an interpreted (human-readable)
+string — through a small C++ shim bound with [`cxx`](https://cxx.rs/). The
+unavoidable FFI `unsafe` is confined to this crate, so dependents can keep
+`#![forbid(unsafe_code)]`.
+
+## Requirements
+
+- `libexiv2` development files (e.g. `libexiv2-dev` on Debian/Ubuntu); discovered
+  at build time via `pkg-config`. exiv2 0.27 and 0.28 are both supported.
+- A C++17 compiler.
+
+## Example
+
+```rust,no_run
+use rahmen_exiv2::Metadata;
+
+let meta = Metadata::new_from_path("image.jpg")?;
+let when = meta.get_tag_interpreted_string("Exif.Photo.DateTimeOriginal")?;
+println!("{when}");
+# Ok::<(), rahmen_exiv2::Exiv2Error>(())
+```
+
+## License
+
+GPL-3.0-only. See the repository's `LICENSE`.


### PR DESCRIPTION
## Summary

Prepares **both** workspace crates for `cargo publish`. Since the merged `rahmen-exiv2` split made `rahmen` depend on a workspace crate via a path dependency, publishing `rahmen` now requires `rahmen-exiv2` to be a published crate too. This supersedes the now-stale #25 (which was based on the pre-`rahmen-exiv2` master).

## The blocker this fixes

`cargo publish` on current master fails with:
```
error: all dependencies must have a version requirement specified when publishing.
  dependency `rahmen-exiv2` does not specify a version
```

## Changes

**`rahmen-exiv2`** (so it can be published first):
- Valid SPDX license — `GPL-3.0-only` (was the non-SPDX `GPL`).
- Added `repository`, `homepage`, `documentation`, `keywords`, `categories`, and a `README.md` so the crates.io page is meaningful.

**`rahmen`**:
- Gave the `rahmen-exiv2` path dependency a version requirement: `{ path = "rahmen-exiv2", version = "0.2.0" }` (required when publishing; the `path` is stripped on upload and the crates.io version is used).
- Valid SPDX license — `GPL-3.0-only`.
- Completed manifest metadata (`repository`/`homepage`/`documentation`/`keywords`/`categories`) and `exclude`d dev-only files (`.github/`, `rustfmt.toml`, `test.py`).
- Refreshed `Cargo.lock` off yanked transitive crates (`crossbeam-channel`/`-utils`, `futures-util`).

## Verification (local, exiv2 0.27.6 / GCC 13.3)
- `cargo build` / `cargo clippy --all-targets -- -D warnings` (default **and** `--features minifb`) / `cargo test` / `cargo fmt --all -- --check` ✅
- `cargo publish --dry-run -p rahmen-exiv2` ✅ — packages 11 files, verification build succeeds, no warnings.
- `cargo publish --dry-run -p rahmen` now fails **only** with `no matching package named rahmen-exiv2 found` — i.e. the manifest is correct and the sole remaining blocker is the publish ordering (expected; resolves once `rahmen-exiv2` is on crates.io).

## How to publish (your tokened step)
```sh
cargo publish -p rahmen-exiv2   # first
cargo publish -p rahmen         # then
```

## Notes
- `license` is `GPL-3.0-only` on both crates; switch to `GPL-3.0-or-later` if you intend "v3 or later".
- `docs.rs` builds for both crates may need `[package.metadata.docs.rs]` / system-lib handling (exiv2, gexiv2→exiv2, fontconfig, python) — a post-publish nicety, not a publish blocker.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KQTNpGFjZnPQ6mh61YwTC6)_