### PR TITLE
Add release-plz support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,36 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+  id-token: write
+
+on:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: release-plz
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+      # Required so release-plz can verify the build during `cargo publish`.
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libexiv2-dev libfontconfig1-dev python3-dev
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,16 @@
+[workspace]
+# disable the changelog for all packages
+changelog_update = false
+
+[[package]]
+name = "rahmen"
+# enable the changelog for this package
+changelog_update = true
+# set the path of the changelog to the root of the repository
+changelog_path = "./CHANGELOG.md"
+version_group = "rahmen"
+
+# We want all packages to track the same version.
+[[package]]
+name = "rahmen-exiv2"
+version_group = "rahmen"


### PR DESCRIPTION
Configure release-plz to manage versioning and crates.io publishing.
`rahmen` and `rahmen-exiv2` share a version group, so they release in lockstep with a single changelog at the repo root.

Publishing uses crates.io trusted publishing (OIDC), so no registry token is stored.
The workflow installs libexiv2 and friends so the publish-time build verification succeeds.

Also adds a Dependabot config for GitHub Actions and Cargo.

Requires registering a trusted publisher on crates.io for both `rahmen` and `rahmen-exiv2` (repo `antiguru/rahmen`, workflow `release-plz.yml`) before the first release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)