### PR TITLE
Update to timely 0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,23 +3,6 @@
 version = 4
 
 [[package]]
-name = "abomonation"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e72913c99b1f927aa7bd59a41518fdd9995f63ffc8760f211609e0241c4fb2"
-
-[[package]]
-name = "abomonation_derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50e2a046af56a864c62d97b7153fda72c596e646be1b0c7963736821f6e1efa"
-dependencies = [
- "proc-macro2",
- "quote",
- "synstructure",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +86,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,9 +129,9 @@ checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "byteorder-lite"
@@ -217,7 +209,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.8",
 ]
 
 [[package]]
@@ -225,6 +217,38 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "columnar"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b280b1509d6a79dccc29a809a4eda5916af652d479afb0e27f7718af6639f1"
+dependencies = [
+ "bytemuck",
+ "columnar_derive",
+ "smallvec",
+]
+
+[[package]]
+name = "columnar_derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c9c88441fb60d0d5d9e939b5765abdff87d1a4d4cc80a90e0f945a6711c438"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "columnation"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90b1614014f6958477dcdb77a2d489555db48ca61efe94c5cde2b0446933ed1"
+dependencies = [
+ "paste",
+ "smallvec",
+]
 
 [[package]]
 name = "config"
@@ -319,21 +343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,7 +380,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -385,7 +394,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -403,7 +412,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -630,7 +639,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -717,7 +726,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -757,11 +766,11 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "getopts"
-version = "0.2.21"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -902,7 +911,7 @@ checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1161,6 +1170,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,7 +1253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1298,7 +1313,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1311,7 +1326,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1534,7 +1549,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1582,23 +1597,15 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "syn"
-version = "1.0.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
 
 [[package]]
 name = "syn"
@@ -1609,18 +1616,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.75",
- "unicode-xid",
 ]
 
 [[package]]
@@ -1668,7 +1663,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1684,49 +1679,59 @@ dependencies = [
 
 [[package]]
 name = "timely"
-version = "0.12.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "211e9686a84038d2b052c1f70d7423f8716330fb7108fe21a8a9b0c2929b80a7"
+checksum = "c5af6859fde675a87f12da672e0bdf08bfc809e68d8c6728f50942d09c0480a3"
 dependencies = [
- "abomonation",
- "abomonation_derive",
- "crossbeam-channel",
- "futures-util",
+ "bincode",
+ "byteorder",
+ "columnar",
+ "columnation",
  "getopts",
+ "itertools",
  "serde",
- "serde_derive",
+ "smallvec",
  "timely_bytes",
  "timely_communication",
+ "timely_container",
  "timely_logging",
 ]
 
 [[package]]
 name = "timely_bytes"
-version = "0.12.2"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99223f9594ab7d4dd36b55b1d7eb9bd2cd205f4304b5cc5381d5cdd417ec06f2"
+checksum = "4b427b919d60d815c9c30b52d8080ebde599380db18c7c98a8c99fc172601ca1"
 
 [[package]]
 name = "timely_communication"
-version = "0.12.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3435bab8a9b9909b5bc907cc562b3659c62a05c1abbc1268e914b024b66dff60"
+checksum = "2137e50f9c368c04d9971b7909c6fceadedb24c6e4fa4173bf55bf6d415329db"
 dependencies = [
- "abomonation",
- "abomonation_derive",
- "crossbeam-channel",
+ "byteorder",
+ "columnar",
  "getopts",
  "serde",
- "serde_derive",
  "timely_bytes",
+ "timely_container",
  "timely_logging",
 ]
 
 [[package]]
-name = "timely_logging"
-version = "0.12.1"
+name = "timely_container"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73a034d62792b507397701ee660001c8ba3e9dbffce29bc7a25319a36ebaa86"
+checksum = "b45d41809553b99db9abc2ad2c5f5b8f755df1f2191051527deaadeea12d5a7e"
+
+[[package]]
+name = "timely_logging"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00582f3cfc652e3173eb9a140981133f359029e6b746667414a8d334285163d6"
+dependencies = [
+ "timely_container",
+]
 
 [[package]]
 name = "toml"
@@ -1776,6 +1781,12 @@ name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -1876,7 +1887,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2106,7 +2117,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2122,7 +2133,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rahmen"
 version = "0.2.0"
 authors = ["Moritz Hoffmann <antiguru@gmail.com>", "sys3175 <https://github.com/sys3175>"]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.86"
 license = "GPL-3.0-only"
 description = "Rahmen is a lightweight image presenter"
 readme = "README.md"
@@ -45,7 +45,7 @@ pathfinder_geometry = "0.5"
 rahmen-exiv2 = { path = "rahmen-exiv2", version = "0.2.0" }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
-timely = "0.12"
+timely = "0.30"
 xdg = "3"
 
 [dependencies.image]

--- a/src/bin/rahmen.rs
+++ b/src/bin/rahmen.rs
@@ -223,13 +223,15 @@ fn main() -> RahmenResult<()> {
     let time_format = settings.time_format.unwrap_or("%H:%M:%S".into());
 
     // initialization for timely dataflow
-    let allocator =
-        Allocator::Thread(timely::communication::allocator::thread::Thread::default());
-    let mut worker = timely::worker::Worker::new(Config::default(), allocator, Some(Instant::now()));
+    let allocator = Allocator::Thread(timely::communication::allocator::thread::Thread::default());
+    let mut worker =
+        timely::worker::Worker::new(Config::default(), allocator, Some(Instant::now()));
 
     // input: #1 timeline #2 screen resolution
-    let mut input_configuration: InputHandle<Duration, CapacityContainerBuilder<Vec<Configuration>>> =
-        InputHandle::new();
+    let mut input_configuration: InputHandle<
+        Duration,
+        CapacityContainerBuilder<Vec<Configuration>>,
+    > = InputHandle::new();
     // to gather information about progress
     let probe = ProbeHandle::new();
 

--- a/src/bin/rahmen.rs
+++ b/src/bin/rahmen.rs
@@ -11,13 +11,15 @@ use image::{DynamicImage, GenericImageView};
 use log::{error, info, warn};
 use pyo3::prelude::*;
 use pyo3::types::PyList;
+use timely::communication::Allocator;
+use timely::container::CapacityContainerBuilder;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::capture::Event;
+use timely::dataflow::operators::vec::{Branch, Filter, Map, ResultStream};
 use timely::dataflow::operators::{
-    Branch, Capture, Concat, ConnectLoop, Enter, Filter, Inspect, Leave, LoopVariable, Map,
-    Notificator, Operator, Probe, ResultStream,
+    Capture, Concat, ConnectLoop, Enter, Inspect, Leave, LoopVariable, Notificator, Operator, Probe,
 };
-use timely::dataflow::{InputHandle, ProbeHandle, Scope};
+use timely::dataflow::{InputHandle, ProbeHandle};
 use timely::order::Product;
 use timely::worker::Config;
 
@@ -221,13 +223,15 @@ fn main() -> RahmenResult<()> {
     let time_format = settings.time_format.unwrap_or("%H:%M:%S".into());
 
     // initialization for timely dataflow
-    let allocator = timely::communication::allocator::Thread::new();
-    let mut worker = timely::worker::Worker::new(Config::default(), allocator);
+    let allocator =
+        Allocator::Thread(timely::communication::allocator::thread::Thread::default());
+    let mut worker = timely::worker::Worker::new(Config::default(), allocator, Some(Instant::now()));
 
     // input: #1 timeline #2 screen resolution
-    let mut input_configuration: InputHandle<_, Configuration> = InputHandle::new();
+    let mut input_configuration: InputHandle<Duration, CapacityContainerBuilder<Vec<Configuration>>> =
+        InputHandle::new();
     // to gather information about progress
-    let mut probe = ProbeHandle::new();
+    let probe = ProbeHandle::new();
 
     let output = worker.dataflow(|scope| {
         let configuration_stream = input_configuration.to_stream(scope);
@@ -235,9 +239,10 @@ fn main() -> RahmenResult<()> {
         let img_path_stream = scope.scoped::<Product<_, u32>, _, _>("File loading", |inner| {
             let (handle, cycle) = inner.loop_variable(1);
             let (ok, err) = configuration_stream
+                .clone()
                 .filter(|c| matches!(c, Configuration::Tick))
                 .enter(inner)
-                .concat(&cycle)
+                .concat(cycle)
                 // obtain next path
                 .map(move |_| fatal_err(provider.next_image()))
                 // Load image
@@ -249,18 +254,18 @@ fn main() -> RahmenResult<()> {
                 })
                 .branch(|_t, d| d.as_ref().err() == Some(&RunControl::Suppressed));
             err.map(|_| Configuration::Tick).connect_loop(handle);
-            ok.leave()
+            ok.leave(scope)
         });
-        let err_stream = img_path_stream.err();
+        let err_stream = img_path_stream.clone().err();
 
-        let mut buffer = vec![];
         let mut stash: HashMap<Duration, String> = HashMap::new();
         let mut current_text = None;
 
         let mut status_line_stream = img_path_stream
+            .clone()
             .ok()
             .flat_map(move |(p, _img)| status_line_formatter.format(&p).ok())
-            .concat(&configuration_stream.flat_map(|c| match c {
+            .concat(configuration_stream.clone().flat_map(|c| match c {
                 Configuration::Greeting(text) => Some(text),
                 _ => None,
             }))
@@ -272,10 +277,9 @@ fn main() -> RahmenResult<()> {
                 Some(Duration::from_secs(0)),
                 move |input, output, not: &mut Notificator<Duration>| {
                     input.for_each(|cap, data| {
-                        data.swap(&mut buffer);
-                        if let Some(text) = buffer.drain(..).next_back() {
+                        if let Some(text) = data.drain(..).next_back() {
                             *stash.entry(*cap.time()).or_default() = text;
-                            not.notify_at(cap.retain());
+                            not.notify_at(cap.retain(0));
                         }
                     });
                     not.for_each(|cap, cnt, not| {
@@ -310,20 +314,18 @@ fn main() -> RahmenResult<()> {
 
         let adjusted_configuration_stream = {
             let mut stash: HashMap<_, Vec<_>> = HashMap::new();
-            let mut buffer = vec![];
             // Hack: adjust screen size for the resize operator to reserve space for the status line
             let mut current_font_size = None;
             let mut current_font_canvas_vstretch = None;
 
-            configuration_stream.unary_notify(
+            configuration_stream.clone().unary_notify(
                 Pipeline,
                 "Adjust configuration",
                 None,
                 move |input, output, not| {
                     input.for_each(|cap, data| {
-                        data.swap(&mut buffer);
-                        stash.entry(*cap.time()).or_default().append(&mut buffer);
-                        not.notify_at(cap.retain());
+                        stash.entry(*cap.time()).or_default().append(data);
+                        not.notify_at(cap.retain(0));
                     });
                     not.for_each(|cap, _, _not| {
                         if let Some(updates) = stash.remove(cap.time()) {
@@ -361,9 +363,10 @@ fn main() -> RahmenResult<()> {
         };
 
         let img_stream = img_path_stream
+            .clone()
             .ok()
             .map(|(_, img)| img)
-            .concat(&configuration_stream.flat_map(|c| match c {
+            .concat(configuration_stream.clone().flat_map(|c| match c {
                 Configuration::Splash(img) => Some(img),
                 _ => None,
             }))
@@ -372,19 +375,14 @@ fn main() -> RahmenResult<()> {
         let mut size_stash: HashMap<usize, _> = HashMap::new();
         let mut input_buffer: HashMap<_, Vec<(_, _, _)>> = HashMap::new();
 
-        let composed_img_stream = img_stream.concat(&text_img_stream).unary_notify(
+        let composed_img_stream = img_stream.concat(text_img_stream).unary_notify(
             Pipeline,
             "Infer blanking",
             None,
             move |input, output, not| {
-                let mut buffer = vec![];
                 input.for_each(|time, data| {
-                    data.swap(&mut buffer);
-                    input_buffer
-                        .entry(*time.time())
-                        .or_default()
-                        .append(&mut buffer);
-                    not.notify_at(time.retain());
+                    input_buffer.entry(*time.time()).or_default().append(data);
+                    not.notify_at(time.retain(0));
                 });
                 not.for_each(|time, _count, _not| {
                     if let Some(updates) = input_buffer.remove(time.time()) {
@@ -408,8 +406,8 @@ fn main() -> RahmenResult<()> {
 
         err_stream
             .map(Err)
-            .concat(&composed_img_stream.map(Ok))
-            .probe_with(&mut probe)
+            .concat(composed_img_stream.map(Ok))
+            .probe_with(&probe)
             .capture()
     });
 

--- a/src/dataflow.rs
+++ b/src/dataflow.rs
@@ -6,18 +6,19 @@ use std::sync::Arc;
 use crate::font::FontRenderer;
 use crate::{Timer, Vector};
 use image::{DynamicImage, GenericImageView};
+use timely::dataflow::Stream;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::Operator;
-use timely::dataflow::{Scope, Stream};
+use timely::progress::Timestamp;
 
 /// A stream of images
-pub type ImageStream<S> = Stream<S, Arc<DynamicImage>>;
+pub type ImageStream<'a, T> = Stream<'a, T, Vec<Arc<DynamicImage>>>;
 
 /// A keyed stream of offset and image
-pub type ImagePosStream<S> = Stream<S, (usize, Vector, Arc<DynamicImage>)>;
+pub type ImagePosStream<'a, T> = Stream<'a, T, Vec<(usize, Vector, Arc<DynamicImage>)>>;
 
 /// A configuration stream
-pub type ConfigurationStream<S> = Stream<S, Configuration>;
+pub type ConfigurationStream<'a, T> = Stream<'a, T, Vec<Configuration>>;
 
 /// A configuration element to be passed in a configuration stream
 #[derive(Debug, Clone)]
@@ -37,33 +38,31 @@ pub enum Configuration {
 }
 
 /// Format text for the status line trait
-pub trait FormatText<S: Scope> {
+pub trait FormatText<'a, T: Timestamp + std::hash::Hash> {
     /// Format text stream operation
     fn format_text(
         &self,
-        configuration_stream: &ConfigurationStream<S>,
+        configuration_stream: &ConfigurationStream<'a, T>,
         font_renderer: FontRenderer,
         key: usize,
-    ) -> ImagePosStream<S>;
+    ) -> ImagePosStream<'a, T>;
 }
 
-impl<S: Scope> FormatText<S> for Stream<S, Vec<String>> {
+impl<'a, T: Timestamp + std::hash::Hash> FormatText<'a, T> for Stream<'a, T, Vec<Vec<String>>> {
     fn format_text(
         &self,
-        configuration_stream: &ConfigurationStream<S>,
+        configuration_stream: &ConfigurationStream<'a, T>,
         mut font_renderer: FontRenderer,
         key: usize,
-    ) -> ImagePosStream<S> {
+    ) -> ImagePosStream<'a, T> {
         let mut configuration_stash = HashMap::new();
         let mut text_stash = HashMap::new();
         let mut current_screen_dimension = None;
         let mut current_font_size = None;
         let mut current_font_canvas_vstretch = None;
         let mut current_text = None;
-        let mut in_buffer1 = vec![];
-        let mut in_buffer2 = vec![];
-        self.binary_notify(
-            configuration_stream,
+        self.clone().binary_notify(
+            configuration_stream.clone(),
             Pipeline,
             Pipeline,
             "Format text",
@@ -71,21 +70,19 @@ impl<S: Scope> FormatText<S> for Stream<S, Vec<String>> {
             move |in1, in2, out, not| {
                 let _t = Timer::new(|e| debug!("Render font op {}ms", e.as_millis()));
                 in1.for_each(|time, data| {
-                    data.swap(&mut in_buffer1);
-                    for text in in_buffer1.drain(..) {
+                    for text in data.drain(..) {
                         text_stash.insert(time.time().clone(), text);
                     }
-                    not.notify_at(time.retain());
+                    not.notify_at(time.retain(0));
                 });
                 in2.for_each(|time, data| {
-                    data.swap(&mut in_buffer2);
-                    for configuration in in_buffer2.drain(..) {
+                    for configuration in data.drain(..) {
                         configuration_stash
                             .entry(time.time().clone())
                             .or_insert_with(Vec::new)
                             .push(configuration);
                     }
-                    not.notify_at(time.retain());
+                    not.notify_at(time.retain(0));
                 });
                 not.for_each(|time, _cnt, _not| {
                     if let Some(configurations) = configuration_stash.remove(time.time()) {
@@ -140,29 +137,27 @@ impl<S: Scope> FormatText<S> for Stream<S, Vec<String>> {
 }
 
 /// Resize an image to match its viewport size
-pub trait ResizeImage<S: Scope> {
+pub trait ResizeImage<'a, T: Timestamp + std::hash::Hash> {
     /// Resize an image
     fn resize_image(
         &self,
-        configuration_stream: &ConfigurationStream<S>,
+        configuration_stream: &ConfigurationStream<'a, T>,
         key: usize,
-    ) -> ImagePosStream<S>;
+    ) -> ImagePosStream<'a, T>;
 }
 
-impl<S: Scope> ResizeImage<S> for ImageStream<S> {
+impl<'a, T: Timestamp + std::hash::Hash> ResizeImage<'a, T> for ImageStream<'a, T> {
     fn resize_image(
         &self,
-        configuration_stream: &ConfigurationStream<S>,
+        configuration_stream: &ConfigurationStream<'a, T>,
         key: usize,
-    ) -> ImagePosStream<S> {
-        let mut buffer1 = vec![];
-        let mut buffer2 = vec![];
+    ) -> ImagePosStream<'a, T> {
         let mut img_stash = HashMap::new();
         let mut configuration_stash = HashMap::new();
         let mut current_screen_size = None;
         let mut current_image = None;
-        self.binary_notify(
-            configuration_stream,
+        self.clone().binary_notify(
+            configuration_stream.clone(),
             Pipeline,
             Pipeline,
             "Resize image",
@@ -170,21 +165,19 @@ impl<S: Scope> ResizeImage<S> for ImageStream<S> {
             move |in1, in2, out, not| {
                 let _t = Timer::new(|e| debug!("Resize image op {}ms", e.as_millis()));
                 in1.for_each(|time, data| {
-                    data.swap(&mut buffer1);
-                    for img in buffer1.drain(..) {
+                    for img in data.drain(..) {
                         img_stash.insert(time.time().clone(), img);
                     }
-                    not.notify_at(time.retain());
+                    not.notify_at(time.retain(0));
                 });
                 in2.for_each(|time, data| {
-                    data.swap(&mut buffer2);
-                    for configuration in buffer2.drain(..) {
+                    for configuration in data.drain(..) {
                         configuration_stash
                             .entry(time.time().clone())
                             .or_insert_with(Vec::new)
                             .push(configuration);
                     }
-                    not.notify_at(time.retain());
+                    not.notify_at(time.retain(0));
                 });
                 not.for_each(|time, _cnt, _not| {
                     if let Some(configurations) = configuration_stash.remove(time.time()) {


### PR DESCRIPTION
## Summary

Updates the `timely` dependency from 0.12 to 0.30. This release carries a substantial API redesign, so the dataflow code in `src/bin/rahmen.rs` and `src/dataflow.rs` was reworked accordingly while preserving the existing behavior.

## Key API changes addressed

- **`Scope` is now a struct** (`Scope<'scope, T>`) rather than a trait, and **`Stream` is parameterized by timestamp and container** (`Stream<'scope, T, C>`). The `FormatText` / `ResizeImage` traits are now generic over the scope lifetime and timestamp instead of over a `Scope` type parameter; the stream type aliases gained a `'a` lifetime and timestamp parameter.
- **`Map`, `Filter`, `Branch`, `ResultStream`** moved under `timely::dataflow::operators::vec`; imports updated.
- **Operators consume the stream by value**, so streams that are reused (`configuration_stream`, `img_path_stream`) are now `.clone()`d at each use.
- **Input handles in `for_each` yield `&mut C` directly**, replacing the old `RefOrMut::swap` buffer dance with draining/appending the container in place.
- **`InputCapability::retain` now takes an output port index** (`retain(0)`).
- **`Worker::new` takes a concrete `Allocator` plus an optional timer**; the thread worker is built via `Allocator::Thread(...)` and `Some(Instant::now())`.
- **`leave` takes the outer scope**, and **`probe_with` takes a shared reference**.
- Bumped `rust-version` to 1.86 as required by timely 0.30.

## Testing

- `cargo build` — clean
- `cargo clippy` — clean
- `cargo test` — passes (no tests defined)
- `cargo check --features minifb` — clean
- `./target/debug/rahmen --help` runs

> Note: building locally requires `libexiv2-dev` for the `rahmen-exiv2` workspace crate.

https://claude.ai/code/session_01BsczChhAPtnoLfDVe1zh9j

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsczChhAPtnoLfDVe1zh9j)_